### PR TITLE
Fix bounding boxes of modrinth button and navigation bar and customize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# next-template
+<p align="center">
+  <img alt="MCSR Logo" src="public/icon_x256.png" />
+</p>
 
-A Next.js 13 template for building apps with Radix UI and Tailwind CSS.
+# MCSR Ranked Webpage
+
+The Website of MCSR Ranked, hosted at [mcsrranked.com](https://mcsrranked.com/).
 
 ## Usage
 
 ```bash
-npx create-next-app -e https://github.com/shadcn/next-template
+git clone git@github.com:MCSR-Ranked/webpage.git
+cd webpage
+npm install
+npm run dev
 ```
 
 ## Features

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -146,17 +146,17 @@ export default function DownloadPage() {
                 Download only Mod File (.jar)
               </h2>
               <p className="text-sm">
-                If you want to download only mod file(.jar), go to the Modrinth
+                If you want to download only mod file (.jar), go to the Modrinth
                 page.
               </p>
-              <Button className="mt-4">
-                <Link
-                  href="https://modrinth.com/mod/mcsr-ranked/versions/"
-                  target="_blank"
-                >
-                  Download (Modrinth)
-                </Link>
-              </Button>
+              <Link
+                href="https://modrinth.com/mod/mcsr-ranked/versions/"
+                target="_blank"
+              >
+                <Button className="mt-4">
+                    Download (Modrinth)
+                </Button>
+              </Link>
             </div>
             <div className="w-full px-4 lg:w-1/2">
               <h2 className="text-2xl font-semibold">

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -13,7 +13,7 @@ interface MainNavProps {
 
 export function MainNav({ items }: MainNavProps) {
   return (
-    <div className="hidden gap-6 md:flex md:gap-10">
+    <div className="hidden gap-6 md:flex md:gap-10 h-full">
       <Link href="/" className="flex items-center space-x-2">
         <Image src={"/icon_x256.png"} alt="MCSR Logo" width={48} height={48} />
         <span className="inline-block font-bold">{siteConfig.name}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "next-template",
+  "name": "mcsr-ranked-webpage",
   "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-template",
+      "name": "mcsr-ranked-webpage",
       "version": "0.0.2",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-template",
+  "name": "mcsr-ranked-webpage",
   "version": "0.0.2",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The first of these two commits fixes links not filling the full height of their containers (the modrinth link button and the navigation buttons).

The second commit changes the the project name in package.json from the default and customizes the README.